### PR TITLE
Fix API base path to resolve data loading error

### DIFF
--- a/src/api/gbb.js
+++ b/src/api/gbb.js
@@ -1,8 +1,11 @@
-const BASE_URL = 'https://gbbwa.aemo.com.au/api/v1';
+// Use relative path so Netlify redirect can proxy requests in production
+// and avoid CORS issues when loading data
+const BASE_URL = '/api';
 
 export const fetchGasData = async (endpoint, params = {}) => {
   try {
-    const url = new URL(`${BASE_URL}${endpoint}`);
+    // Construct URL relative to current origin
+    const url = new URL(`${BASE_URL}${endpoint}`, window.location.origin);
     Object.keys(params).forEach(key => {
       if (params[key] !== undefined && params[key] !== null) {
         url.searchParams.append(key, params[key]);


### PR DESCRIPTION
## Summary
- Fetch gas data through relative `/api` path so Netlify can proxy requests
- Build full URL using current origin to avoid CORS problems

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68b66b142b948323ba590908b9453d13